### PR TITLE
Simplify the date logic for start and end

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const spreadsheet = require('./spreadsheet');
 
 function run() {
   require('lambda-git')().then(() => {
-    console.log('git should be installed and available for use');
+    console.log('git should now be installed and available for use');
     spreadsheet.readSpreadsheet();
   });
 }

--- a/spreadsheet.js
+++ b/spreadsheet.js
@@ -41,13 +41,14 @@ function getRowsFromSheet(sheet) {
     }
 
     _.each(rows, (candidate) => {
-      // If the candidate's start date is within the next 24 hours we need to enable the software engineering assignment.
-      // If the candidate's window ends within the next 24 hours we need to revoke access.
+      // If the candidate's start date is today we need to enable the software engineering assignment.
+      // If the candidate's window ends today we need to revoke access.
+      // All this works because we expect this code to be run only once per day.
       const parsedStart = moment(candidate.start);
       const today = moment();
-      const tomorrow = moment().add(1, 'day');
       const parsedEnd = moment(candidate.start).add(candidate.window, 'hours');
-      if (parsedStart.isAfter(today) && parsedStart.isBefore(tomorrow)) {
+      console.log(`Parsed Start Date ${parsedStart}; today is ${today}; parsed end date is ${parsedEnd}`);
+      if (parsedStart.isSame(today, 'day')) {
         console.log(`Starting assignment for ${candidate.candidatename}, officially starting at ${candidate.start}`);
         repos.initializeCandidate({
           templateRepo: candidate.assignment,
@@ -56,7 +57,7 @@ function getRowsFromSheet(sheet) {
         });
         candidate.assigned = today.toString();
         candidate.save();
-      } else if (parsedEnd.isAfter(moment()) && parsedEnd.isBefore(moment().add(1, 'day'))) {
+      } else if (parsedEnd.isSame(today, 'day')) {
         console.log(`Ending assignment for ${candidate.candidatename}, officially started at ${candidate.start} with a ${candidate.window}-hour window.`);
         repos.removeCollaboratorAccess({
           templateRepo: candidate.assignment,


### PR DESCRIPTION
Instead of checking if the start date is after now and before now + 24h, we just compare the date using moment's `isSame` method, specifying `day` as the granularity for comparison. See [the moment API docs](http://momentjs.com/docs/#/query/is-same/).