### PR TITLE
Load Environment Variables From .env When Running Locally

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -1,0 +1,17 @@
+# For more information on where to retrieve these keys
+# see the README section on Environment Variables: https://github.com/builtforme/CodeBnb#aws-lambda
+
+GITHUB_ORG=
+GITHUB_USER_TOKEN=
+
+SPREADSHEET_KEY=
+GOOGLE_CLIENT_EMAIL=
+GOOGLE_PRIVATE_KEY=
+
+AWS_API_GATEWAY_ENDPOINT=
+
+ADD_CANDIDATE_AUTHORIZATION_CODE
+
+EMAIL_FROM=
+
+REVOCATION_NOTIFICATION_RECEPIENT=

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ node_modules
 
 # Code Coverage Reports
 /coverage
+
+# Environment Variable File
+.env

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ All actions taken by CodeBnb are recorded in the Google Spreadsheet, and you don
 3. Select the "Upload a .ZIP file" as your "Code entry type" and upload `lambda.zip` generated in step 1.
 4. Click `Save and test` and troubleshoot, repeating steps 1, 3, and 4 until you see success.
 
+#### Environment Variables
+
 You need to set some environment variables in your AWS Lambda function:
 
 `GITHUB_ORG` - The name of the organization under which software assignments will be created (and in which the template repository lives).
@@ -46,6 +48,8 @@ You need to set some environment variables in your AWS Lambda function:
 `EMAIL_FROM` - The email address used as the sender for email-based notifications.
 
 `REVOCATION_NOTIFICATION_RECEPIENT` - Email address to receive notifications when a candidate's access is revoked.
+
+If running locally, you can simply store these keys in a `.env` file and they will automatically be loaded into your environment.
 
 ### AWS API Gateway Setup
 Configure a new API Gateway with two resources:

--- a/index.js
+++ b/index.js
@@ -1,3 +1,6 @@
+// Needs to be first to load in environment variables
+// from .env file
+require('dotenv').config();
 const spreadsheet = require('./spreadsheet');
 const fs = require('fs');
 const str = require('underscore.string');

--- a/package-lock.json
+++ b/package-lock.json
@@ -851,7 +851,6 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
-<<<<<<< HEAD
     "detect-indent": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
@@ -877,12 +876,11 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
       "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
       "dev": true
-=======
+    },
     "dotenv": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
       "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
->>>>>>> 0279eb6... Make it easier to load environment variables when running locally by using a .env file.
     },
     "ecc-jsbn": {
       "version": "0.1.1",
@@ -1168,7 +1166,7 @@
       "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
       "dev": true,
       "requires": {
-        "samsam": "1.2.1"
+        "samsam": "1.3.0"
       }
     },
     "fs.realpath": {
@@ -3672,9 +3670,9 @@
       "integrity": "sha1-OBiPTWUKOkdCWEObluxFsyYXEzw="
     },
     "lolex": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.1.2.tgz",
-      "integrity": "sha1-JpS5U8nqTQE+W4v7qJHJkQJbJik=",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.1.3.tgz",
+      "integrity": "sha512-BdHq78SeI+6PAUtl4atDuCt7L6E4fab3mSRtqxm4ywaXe4uP7jZ0TTcFNuU20syUjxZc2l7jFqKVMJ+AX0LnpQ==",
       "dev": true
     },
     "longest": {
@@ -3851,9 +3849,9 @@
       "integrity": "sha1-a+lPysqNd63gqWcNxGCRTJRHJEQ="
     },
     "nise": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.1.0.tgz",
-      "integrity": "sha512-lIFidCxB0mJGyq1i33tLRNojtMoYX95EAI7WQEU+/ees0w6hvXZQHZ7WD130Tjeh5+YJAUVLfQ3k/s9EA8jj+w==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.1.1.tgz",
+      "integrity": "sha512-f5DMJB0MqBaSuP2NAwPx7HyVKPdaozds0KsNe9XIP3npKWt/QUg73l5TTLRTSwfG/Y3AB0ktacuxX4QNcg6vVw==",
       "dev": true,
       "requires": {
         "formatio": "1.2.0",
@@ -4457,9 +4455,9 @@
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "samsam": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz",
-      "integrity": "sha1-7dOQk6MYQ3DLhZJDsr3yVefY6mc=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
       "dev": true
     },
     "sane": {
@@ -4522,19 +4520,19 @@
       "dev": true
     },
     "sinon": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.0.0.tgz",
-      "integrity": "sha1-pUpfAjeqHdIhXl6ByJtCtQxP22s=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.0.1.tgz",
+      "integrity": "sha512-4qIY0pCWCvGCJpV/1JkFu9kbsNEZ9O34cG1oru/c7OCDtrEs50Gq/VjkA2ID5ZwLyoNx1i1ws118oh/p6fVeDg==",
       "dev": true,
       "requires": {
         "diff": "3.3.1",
         "formatio": "1.2.0",
         "lodash.get": "4.4.2",
-        "lolex": "2.1.2",
+        "lolex": "2.1.3",
         "native-promise-only": "0.8.1",
-        "nise": "1.1.0",
+        "nise": "1.1.1",
         "path-to-regexp": "1.7.0",
-        "samsam": "1.2.1",
+        "samsam": "1.3.0",
         "text-encoding": "0.6.4",
         "type-detect": "4.0.3"
       }
@@ -4625,7 +4623,6 @@
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-<<<<<<< HEAD
     },
     "string-length": {
       "version": "2.0.0",
@@ -4691,13 +4688,6 @@
           }
         }
       }
-=======
->>>>>>> 0279eb6... Make it easier to load environment variables when running locally by using a .env file.
-    },
-    "string-template": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
-      "integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0="
     },
     "stringstream": {
       "version": "0.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -851,6 +851,7 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
+<<<<<<< HEAD
     "detect-indent": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
@@ -876,6 +877,12 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
       "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
       "dev": true
+=======
+    "dotenv": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
+      "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
+>>>>>>> 0279eb6... Make it easier to load environment variables when running locally by using a .env file.
     },
     "ecc-jsbn": {
       "version": "0.1.1",
@@ -4618,6 +4625,7 @@
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+<<<<<<< HEAD
     },
     "string-length": {
       "version": "2.0.0",
@@ -4683,6 +4691,13 @@
           }
         }
       }
+=======
+>>>>>>> 0279eb6... Make it easier to load environment variables when running locally by using a .env file.
+    },
+    "string-template": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
+      "integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0="
     },
     "stringstream": {
       "version": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "aws-sdk": "^2.119.0",
     "bluebird": "^3.5.0",
+    "dotenv": "^4.0.0",
     "github": "^11.0.0",
     "google-spreadsheet": "^2.0.4",
     "lambda-git": "^0.1.1",

--- a/repos.js
+++ b/repos.js
@@ -5,7 +5,7 @@ const {exec} = require('child_process');
 const org = process.env.GITHUB_ORG;
 
 const github = new GitHubApi({
-  Promise: require('bluebird'),
+  Promise: Promise,
   timeout: 5000
 });
 
@@ -64,7 +64,7 @@ function initializeCandidate(params) {
   .then(grantCollaboratorAccess)
   .then(() => {
     console.log('repos completed successfully');
-    return `https://github.com/${process.env.GITHUB_ORG}/${candidateRepo}`;
+    return `https://github.com/${org}/${candidateRepo}`;
   })
   .catch((err) => {
     console.log('Caught error in repos ', err);


### PR DESCRIPTION
The purpose of this PR is to make it easier for developers to load their environment variables when running the application locally. AWS Lambda will do this for you, but when running locally you'd have to manually set your environment variables or pass them all in to the start script. This will allow you to simply copy `.env-sample` -> `.env` and then populate the variable values. 
On running the application, these values in this file will automatically be loaded into the environment using https://www.npmjs.com/package/dotenv

@Furchin Not sure if this is something you need or want - but figured I'd create a PR in case it is.