### PR TITLE
Template Repo: Select Instead of Free-Form Text

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ You need to set some environment variables in your AWS Lambda function:
 
 If running locally, you can simply store these keys in a `.env` file and they will automatically be loaded into your environment.
 
+### GitHub Repos
+Assign the "project" [topic](https://help.github.com/articles/about-topics/) to any repo you wish to use as a template repo. When generating a candidate URL, CodeBnb will allow you to select from any _project_ topic repos within your GitHub org.
+
 ### AWS API Gateway Setup
 Configure a new API Gateway with two resources:
 
@@ -78,7 +81,7 @@ Created | This column records the date each row was inserted by CodeBnb.
 GitHub | The candidate's GitHub account username, which is the GitHub account which will be granted `push` rights to the repository.
 assigned | CodeBnb will record a timestamp of when access is granted to the repo. (Leave this column blank when adding new candidates).
 revoked | CodeBnb will record a timestamp of when access is revoked from the repo. (Leave this column blank when adding new candidates).
-revoked | CodeBnb will record a timestamp of when the repo is archived. (Leave this column blank when adding new candidates). Archiving a repo consists of copying it as a subtree within a master project archive repo.
+archived | CodeBnb will record a timestamp of when the repo is archived. (Leave this column blank when adding new candidates). Archiving a repo consists of copying it as a subtree within a master project archive repo.
 
 Note: Column names are case- and whitespace-insensitive. For example, "Candidate Name" and "candidatename" are both acceptable.
 

--- a/html/candidateForm.html
+++ b/html/candidateForm.html
@@ -14,7 +14,11 @@
     Fill out this form to generate a URL to send to the candidate which will allow them to start their assignment.<BR><BR>
       <table>
         <tr><td>Candidate's Full Name:</td><td><input type="text" id="candidateName"></td></tr>
-        <tr><td>Assignment:</td><td><input type="text" id="assignment"></td></tr>
+        <tr><td>Assignment:</td><td><select id="assignment">
+          {{#each repos}}
+            <option value="{{this}}">{{this}}</option>
+          {{/each}}
+        </select></td></tr>
         <tr><td>Duration (hours):</td><td><input type="text" id="duration"></td></tr>
         <tr><td>&nbsp;</td><td><button onClick="javascript:handleSubmit();">Get Assignment URL</button></td></tr>
       </table>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true,
       "requires": {
         "kind-of": "3.2.2",
         "longest": "1.0.1",
@@ -56,8 +55,7 @@
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "ansi-escapes": {
       "version": "3.0.0",
@@ -650,7 +648,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "dev": true,
       "optional": true,
       "requires": {
         "align-text": "0.1.4",
@@ -684,7 +681,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-      "dev": true,
       "optional": true,
       "requires": {
         "center-align": "0.1.3",
@@ -696,7 +692,6 @@
           "version": "0.0.2",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
           "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "dev": true,
           "optional": true
         }
       }
@@ -855,8 +850,7 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -2351,10 +2345,9 @@
       }
     },
     "handlebars": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
-      "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
-      "dev": true,
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "requires": {
         "async": "1.5.2",
         "optimist": "0.6.1",
@@ -2365,14 +2358,12 @@
         "async": {
           "version": "1.5.2",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         },
         "source-map": {
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true,
           "requires": {
             "amdefine": "1.0.1"
           }
@@ -2534,8 +2525,7 @@
     "is-buffer": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
-      "dev": true
+      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -2817,7 +2807,7 @@
       "integrity": "sha1-D7Lj9qqZIr085F0F2KtNXo4HvU8=",
       "dev": true,
       "requires": {
-        "handlebars": "4.0.10"
+        "handlebars": "4.0.11"
       }
     },
     "jest": {
@@ -3617,7 +3607,6 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
       "requires": {
         "is-buffer": "1.1.5"
       }
@@ -3634,7 +3623,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-      "dev": true,
       "optional": true
     },
     "lcid": {
@@ -3718,8 +3706,7 @@
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
     },
     "loose-envify": {
       "version": "1.3.1",
@@ -4013,7 +4000,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.10",
         "wordwrap": "0.0.3"
@@ -4022,8 +4008,7 @@
         "minimist": {
           "version": "0.0.10",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-          "dev": true
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
         }
       }
     },
@@ -4412,8 +4397,7 @@
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "repeating": {
       "version": "1.1.3",
@@ -4474,7 +4458,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true,
       "optional": true,
       "requires": {
         "align-text": "0.1.4"
@@ -4594,8 +4577,7 @@
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "source-map-support": {
       "version": "0.4.18",
@@ -4922,7 +4904,6 @@
       "version": "2.8.29",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-      "dev": true,
       "optional": true,
       "requires": {
         "source-map": "0.5.7",
@@ -4934,7 +4915,6 @@
           "version": "3.10.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "dev": true,
           "optional": true,
           "requires": {
             "camelcase": "1.2.1",
@@ -4949,7 +4929,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "dev": true,
       "optional": true
     },
     "underscore": {
@@ -5096,14 +5075,12 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-      "dev": true,
       "optional": true
     },
     "wordwrap": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-      "dev": true
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
     },
     "worker-farm": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dotenv": "^4.0.0",
     "github": "^11.0.0",
     "google-spreadsheet": "^2.0.4",
+    "handlebars": "^4.0.11",
     "lambda-git": "^0.1.1",
     "moment": "^2.18.1",
     "underscore": "^1.8.3",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.2.0",
+  "version": "2.3.0",
   "scripts": {
     "test": "jest --coverage",
     "zip": "zip -r lambda.zip *.js package.json node_modules html"

--- a/repos.js
+++ b/repos.js
@@ -134,8 +134,29 @@ function removeCollaboratorAccess(params) {
   });
 }
 
+function getProjectRepos() {
+  return new Promise((resolve, reject) => {
+    github.search.repos({
+      q: `user:${process.env.GITHUB_ORG} topic:project`,
+      sort: 'updated',
+      order: 'desc'
+    }, (err, result) => {
+      if (err) {
+        return reject(err);
+      }
+      if (result.data.total_count === 0) {
+        return reject(new Error('No project repositories found.'));
+      }
+      resolve(result.data.items.map((item) => {
+        return item.name;
+      }));
+    })
+  });
+}
+
 module.exports = {
   archiveRepo,
   initializeCandidate,
-  removeCollaboratorAccess
+  removeCollaboratorAccess,
+  getProjectRepos,
 }


### PR DESCRIPTION
With this change, CodeBnb no longer allows free-form entry of the GitHub repo name to be cloned for the candidate. Instead, CodeBnb uses the repo search query `user:<GITHUB_ORG> topic:project` to find all repos with the topic _project_ in the github organization, and uses the result to populate a dropdown. This makes it less likely that someone scheduling a project will insert a typo into the GitHub repo name.

Resolves #24 