### PR TITLE
Adjust timing: Expiration Notification and Archive

### DIFF
--- a/email.js
+++ b/email.js
@@ -71,7 +71,7 @@ exports.sendInvitationExpiringNotification = (candidateNames, emailService = ses
           }
         },
         Subject: {
-          Data: `Project Invitations Expiring Within 24 Hours`
+          Data: `Expired Project Invitations`
         }
       },
       Source: process.env.EMAIL_FROM

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.3.1",
+  "version": "2.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.3.1",
+  "version": "2.3.2",
   "scripts": {
     "test": "jest --coverage",
     "zip": "zip -r lambda.zip *.js package.json node_modules html"

--- a/spreadsheet.js
+++ b/spreadsheet.js
@@ -130,10 +130,10 @@ function scanForExpiringInvitations() {
         expiringInvitations = _.filter(rows, (row) => {
           console.log(`Assigned: ${row.assigned}`);
           console.log(`now: ${moment()}`);
-          return !row.revoked && moment().isSame(moment(row.created).add(INVITATION_VALID_FOR_DAYS, 'days'), 'day');
+          return !row.revoked && moment().isSame(moment(row.created).add(INVITATION_VALID_FOR_DAYS + 1, 'days'), 'day');
         });
 
-        console.log(`Scanned ${rows.length} rows and found ${expiringInvitations.length} invitations expiring in the next day.`);
+        console.log(`Scanned ${rows.length} rows and found ${expiringInvitations.length} invitations expired.`);
 
         if (expiringInvitations.length > 0) {
           email.sendInvitationExpiringNotification(_.str.join(', ', _.pluck(expiringInvitations, 'candidatename')))

--- a/spreadsheet.js
+++ b/spreadsheet.js
@@ -217,7 +217,7 @@ function archiveRepos() {
 
         rowsToArchive = _.filter(rows, (row) => {
           // Allow 14 days before archiving a repo
-          return !row.archived && row.revoked && moment().isAfter(moment(row.revoked).add(14, 'days'));
+          return !row.archived && row.revoked && moment().isAfter(moment(row.revoked).add(30, 'days'));
         });
 
         console.log(`Found ${rowsToArchive.length} repos to archive.`);


### PR DESCRIPTION
Project invitation expiration notification now occurs retroactively -- once it's expired, not in the last 24 hours before it expires. This makes it easier to email a candidate "too bad" without the risk they might open the project in the last moments. 

Archiving the assignment now occurs after 30 days, not 14. 14 days is simply too short.